### PR TITLE
Add option to ignore SimHub running error in installer

### DIFF
--- a/Installer/Installer.nsi
+++ b/Installer/Installer.nsi
@@ -56,10 +56,11 @@ Page Custom DependenciesPage DependenciesPageLeave
 Function .onInit
     ${nsProcess::FindProcess} "SimHubWPF.exe" $R0
     ${If} $R0 == "0"
-        MessageBox MB_ICONEXCLAMATION|MB_RETRYCANCEL "SimHub is running. Please close it before continuing." IDRETRY retry
+        MessageBox MB_ICONEXCLAMATION|MB_ABORTRETRYIGNORE "SimHub is running. Please close it before continuing." IDRETRY retry IDIGNORE ignore
         Quit
         retry:
         Call .onInit ; Retry the check
+        ignore:
     ${EndIf}
 FunctionEnd
 


### PR DESCRIPTION
Added an option to ignore the SimHub running error when installing the plugin.

Background: I have not been able to install the plugin with the installer because SimHub has some orphan processes that refuse to die even after stopping SimHub, cleaning up processes etc.   Once SimHub is stopped of course the installer works fine as there is no lock on the DLL file.    